### PR TITLE
Item display improvements

### DIFF
--- a/src/ap_main.cpp
+++ b/src/ap_main.cpp
@@ -119,7 +119,7 @@ void rrap_location_t::queue_check()
 	AP_SendLocationScouts(scout_ids, 0);
 }
 
-void rrap_location_t::update_displayed_item(srb2::String label, INT64 item_id, srb2::String player)
+void rrap_location_t::update_displayed_item(srb2::String label, INT64 item_id, srb2::String player, UINT8 item_class)
 {
 	/*
 	CONS_Printf(
@@ -157,6 +157,8 @@ void rrap_location_t::update_displayed_item(srb2::String label, INT64 item_id, s
 	{
 		_display_item_player = player;
 	}
+
+	_display_item_class = item_class;
 }
 
 rrap_item_t::rrap_item_t(srb2::JsonValue json)
@@ -421,6 +423,64 @@ rrap_item_t *RRAP_GetItem(INT64 item_id)
 	return &g_ap_item_info[item_id];
 }
 
+UINT16 RRAP_ItemClassToSkinColor(UINT8 item_class)
+{
+	if (item_class & AP_CLASSIFICATION_PROGRESSION)
+	{
+		return SKINCOLOR_LAVENDER;
+	}
+	else if (item_class & AP_CLASSIFICATION_USEFUL)
+	{
+		return SKINCOLOR_BLUE;
+	}
+	else if (item_class & AP_CLASSIFICATION_TRAP)
+	{
+		return SKINCOLOR_RED;
+	}
+	else
+	{
+		return SKINCOLOR_CERULEAN;
+	}
+}
+
+UINT8 RRAP_ItemClassToTextColor(UINT8 item_class)
+{
+	if (item_class & AP_CLASSIFICATION_PROGRESSION)
+	{
+		return 0x89; // lavendermap
+	}
+	else if (item_class & AP_CLASSIFICATION_USEFUL)
+	{
+		return 0x84; // bluemap 
+	}
+	else if (item_class & AP_CLASSIFICATION_TRAP)
+	{
+		return 0x85; // redmap
+	}
+	else
+	{
+		return 0x88; // skymap
+	}
+}
+
+UINT8 RRAP_ItemClassToStars(UINT8 item_class)
+{
+	// Color-blind friendly iconography
+
+	if (item_class & AP_CLASSIFICATION_PROGRESSION)
+	{
+		return 2;
+	}
+	else if (item_class & AP_CLASSIFICATION_USEFUL)
+	{
+		return 1; 
+	}
+	else
+	{
+		return 0;
+	}
+}
+
 boolean RRAP_LocationAvailable(rrap_location_t *location)
 {
 	if (!location)
@@ -524,6 +584,16 @@ char *RRAP_LocationDisplayItemPlayer(rrap_location_t *location)
 	}
 
 	return Z_StrDup( location->display_item_player().c_str() );
+}
+
+UINT8 RRAP_LocationDisplayItemClass(rrap_location_t *location)
+{
+	if (!location)
+	{
+		return AP_CLASSIFICATION_FILLER;
+	}
+
+	return location->display_item_class();
 }
 
 rrap_item_t *RRAP_LocationDisplayItem(rrap_location_t *location)
@@ -1414,7 +1484,8 @@ static void RRAP_GotLocationInfo(std::vector<AP_NetworkItem> network_items)
 		g_ap_location_info[net_item.location].update_displayed_item(
 			net_item.itemName,
 			net_item.item,
-			net_item.playerName
+			net_item.playerName,
+			net_item.flags
 		);
 	}
 }

--- a/src/ap_main.h
+++ b/src/ap_main.h
@@ -28,6 +28,11 @@
 #include "core/json.hpp"
 #endif
 
+#define AP_CLASSIFICATION_FILLER 0b000
+#define AP_CLASSIFICATION_PROGRESSION 0b001
+#define AP_CLASSIFICATION_USEFUL 0b010
+#define AP_CLASSIFICATION_TRAP 0b100
+
 #ifdef __cplusplus
 
 class rrap_location_t
@@ -45,6 +50,7 @@ private:
 	srb2::String _label;
 	srb2::String _display_item_label;
 	srb2::String _display_item_player;
+	UINT8 _display_item_class;
 	INT64 _display_item_id;
 
 public:
@@ -63,12 +69,13 @@ public:
 	srb2::String label() const { return _label; }
 	srb2::String display_item_label() const { return _display_item_label; }
 	srb2::String display_item_player() const { return _display_item_player; }
+	UINT8 display_item_class() const { return _display_item_class; }
 	INT64 display_item_id() const { return _display_item_id; }
 
 	void immediate_check();
 	void queue_check();
 
-	void update_displayed_item(srb2::String label, INT64 item_id, srb2::String player);
+	void update_displayed_item(srb2::String label, INT64 item_id, srb2::String player, UINT8 flags);
 
 	void unqueue_check()
 	{
@@ -176,6 +183,10 @@ rrap_location_t *RRAP_GetLocation(INT64 location_id);
 rrap_item_t *RRAP_GetItem(INT64 item_id);
 void RRAP_LoadArchipelagoJSON(void);
 
+UINT16 RRAP_ItemClassToSkinColor(UINT8 item_class);
+UINT8 RRAP_ItemClassToTextColor(UINT8 item_class);
+UINT8 RRAP_ItemClassToStars(UINT8 item_class);
+
 boolean RRAP_LocationAvailable(rrap_location_t *location);
 boolean RRAP_LocationAchieved(rrap_location_t *location);
 char *RRAP_LocationLabel(rrap_location_t *location);
@@ -187,6 +198,7 @@ boolean RRAP_LocationCheckPending(rrap_location_t *location);
 
 char *RRAP_LocationDisplayItemLabel(rrap_location_t *location);
 char *RRAP_LocationDisplayItemPlayer(rrap_location_t *location);
+UINT8 RRAP_LocationDisplayItemClass(rrap_location_t *location);
 rrap_item_t *RRAP_LocationDisplayItem(rrap_location_t *location);
 
 void RRAP_LocationImmediateCheck(rrap_location_t *location);

--- a/src/k_color.c
+++ b/src/k_color.c
@@ -104,6 +104,37 @@ void K_RainbowColormap(UINT8 *dest_colormap, skincolornum_t skincolor)
 }
 
 /*--------------------------------------------------
+	static void K_MultColormap(UINT8 *dest_colormap, skincolornum_t skincolor)
+
+		Derived from older TC_RAINBOW code. Tries to replicate the
+		same kind of highlighting on text as the V_ flag text can do.
+--------------------------------------------------*/
+static void K_MultColormap(UINT8 *dest_colormap, skincolornum_t skincolor)
+{
+	INT32 i;
+	RGBA_t color;
+	UINT16 brightness;
+
+	// next, for every colour in the palette, choose the transcolor that has the closest brightness
+	for (i = 0; i < NUM_PALETTE_ENTRIES; i++)
+	{
+		color = V_GetColor(i);
+		brightness = color.s.red + color.s.green + color.s.blue;
+
+		brightness = (brightness * 4) / 5; // I want white to become the top-middle of the range, not the top
+		brightness /= 48; // 768 -> 16
+
+		if (brightness > 15)
+		{
+			brightness = 15;
+		}
+		brightness = 15 - brightness;
+
+		dest_colormap[i] = skincolors[skincolor].ramp[brightness];
+	}
+}
+
+/*--------------------------------------------------
 	UINT8 K_HitlagColorValue(RGBA_t color)
 
 		See header file for description.
@@ -264,6 +295,11 @@ void K_GenerateKartColormap(UINT8 *dest_colormap, INT32 skinnum, skincolornum_t 
 	else if (skinnum == TC_RAINBOW)
 	{
 		K_RainbowColormap(dest_colormap, color);
+		return;
+	}
+	else if (skinnum == TC_MULT)
+	{
+		K_MultColormap(dest_colormap, color);
 		return;
 	}
 

--- a/src/k_menudraw.c
+++ b/src/k_menudraw.c
@@ -8581,8 +8581,10 @@ challengedesc:
 		rrap_location_t *ref = RRAP_GetLocation(challengesmenu.current_ap_location);
 		if (ref != NULL)
 		{
+			boolean checked = RRAP_LocationChecked(ref);
 			char *z_str = NULL;
-			if (RRAP_LocationChecked(ref))
+
+			if (checked)
 			{
 				z_str = RRAP_LocationDisplayItemLabel(ref);
 			}
@@ -8594,8 +8596,44 @@ challengedesc:
 			offset = 0;
 			if (z_str)
 			{
+				UINT8 item_class = RRAP_LocationDisplayItemClass(ref);
+				UINT16 label_color = SKINCOLOR_NONE;
+				UINT8 star_count = 0;
+
+				if (checked)
+				{
+					label_color = RRAP_ItemClassToSkinColor(item_class);
+					star_count = RRAP_ItemClassToStars(item_class);
+				}
+
 				offset = V_LSTitleLowStringWidth(z_str, 0) / 2;
-				V_DrawLSTitleLowString(BASEVIDWIDTH/2 - offset, y+6, 0, z_str);
+				V_DrawStringScaled(
+					(BASEVIDWIDTH * FRACUNIT / 2) - (offset * FRACUNIT), (y + 6) * FRACUNIT,
+					FRACUNIT, FRACUNIT, FRACUNIT,
+					0,
+					R_GetTranslationColormap(TC_MULT, label_color, GTC_MENUCACHE),
+					LSLOW_FONT,
+					z_str
+				);
+
+				patch_t *class_star = W_CachePatchName("RHFAV", PU_CACHE);
+				INT32 star_x = (BASEVIDWIDTH / 2) - offset - 4 - (star_count * 10);
+				if (star_x < 8)
+				{
+					star_x = 8;
+				}
+
+				for (i = 0; i < star_count; i++)
+				{
+					V_DrawFixedPatch(
+						star_x * FRACUNIT, (y + 11) * FRACUNIT,
+						FRACUNIT, 0,
+						class_star,
+						R_GetTranslationColormap(TC_RAINBOW, label_color, GTC_MENUCACHE)
+					);
+					star_x += 10;
+				}
+
 				Z_Free(z_str);
 				z_str = NULL;
 			}

--- a/src/r_draw.cpp
+++ b/src/r_draw.cpp
@@ -147,7 +147,8 @@ float zeroheight;
 #define DASHMODE_TT_CACHE_INDEX (MAXSKINS + 6)
 #define HITLAG_TT_CACHE_INDEX (MAXSKINS + 7)
 #define INTERMISSION_TT_CACHE_INDEX (MAXSKINS + 8)
-#define TT_CACHE_SIZE (MAXSKINS + 9)
+#define MULT_TT_CACHE_INDEX (MAXSKINS + 9)
+#define TT_CACHE_SIZE (MAXSKINS + 10)
 
 #define SKIN_RAMP_LENGTH 16
 #define DEFAULT_STARTTRANSCOLOR 96
@@ -160,16 +161,17 @@ static INT32 SkinToCacheIndex(INT32 skinnum)
 {
 	switch (skinnum)
 	{
-		case TC_DEFAULT:    return DEFAULT_TT_CACHE_INDEX;
-		case TC_BOSS:       return BOSS_TT_CACHE_INDEX;
-		case TC_METALSONIC: return METALSONIC_TT_CACHE_INDEX;
-		case TC_ALLWHITE:   return ALLWHITE_TT_CACHE_INDEX;
-		case TC_RAINBOW:    return RAINBOW_TT_CACHE_INDEX;
-		case TC_BLINK:      return BLINK_TT_CACHE_INDEX;
-		case TC_DASHMODE:   return DASHMODE_TT_CACHE_INDEX;
-		case TC_HITLAG:     return HITLAG_TT_CACHE_INDEX;
-		case TC_INTERMISSION: return INTERMISSION_TT_CACHE_INDEX;
-		     default:       break;
+		case TC_DEFAULT:		return DEFAULT_TT_CACHE_INDEX;
+		case TC_BOSS:			return BOSS_TT_CACHE_INDEX;
+		case TC_METALSONIC:		return METALSONIC_TT_CACHE_INDEX;
+		case TC_ALLWHITE:		return ALLWHITE_TT_CACHE_INDEX;
+		case TC_RAINBOW:		return RAINBOW_TT_CACHE_INDEX;
+		case TC_BLINK:			return BLINK_TT_CACHE_INDEX;
+		case TC_DASHMODE:		return DASHMODE_TT_CACHE_INDEX;
+		case TC_HITLAG:			return HITLAG_TT_CACHE_INDEX;
+		case TC_INTERMISSION:	return INTERMISSION_TT_CACHE_INDEX;
+		case TC_MULT:			return MULT_TT_CACHE_INDEX;
+		default:				break;
 	}
 
 	return skinnum;
@@ -179,16 +181,17 @@ static INT32 CacheIndexToSkin(INT32 ttc)
 {
 	switch (ttc)
 	{
-		case DEFAULT_TT_CACHE_INDEX:    return TC_DEFAULT;
-		case BOSS_TT_CACHE_INDEX:       return TC_BOSS;
-		case METALSONIC_TT_CACHE_INDEX: return TC_METALSONIC;
-		case ALLWHITE_TT_CACHE_INDEX:   return TC_ALLWHITE;
-		case RAINBOW_TT_CACHE_INDEX:    return TC_RAINBOW;
-		case BLINK_TT_CACHE_INDEX:      return TC_BLINK;
-		case DASHMODE_TT_CACHE_INDEX:   return TC_DASHMODE;
-		case HITLAG_TT_CACHE_INDEX:     return TC_HITLAG;
-		case INTERMISSION_TT_CACHE_INDEX: return TC_INTERMISSION;
-		     default:                   break;
+		case DEFAULT_TT_CACHE_INDEX:		return TC_DEFAULT;
+		case BOSS_TT_CACHE_INDEX:			return TC_BOSS;
+		case METALSONIC_TT_CACHE_INDEX:		return TC_METALSONIC;
+		case ALLWHITE_TT_CACHE_INDEX:		return TC_ALLWHITE;
+		case RAINBOW_TT_CACHE_INDEX:		return TC_RAINBOW;
+		case BLINK_TT_CACHE_INDEX:			return TC_BLINK;
+		case DASHMODE_TT_CACHE_INDEX:		return TC_DASHMODE;
+		case HITLAG_TT_CACHE_INDEX:			return TC_HITLAG;
+		case INTERMISSION_TT_CACHE_INDEX:	return TC_INTERMISSION;
+		case MULT_TT_CACHE_INDEX:			return TC_MULT;
+		default:						break;
 	}
 
 	return ttc;

--- a/src/r_draw.h
+++ b/src/r_draw.h
@@ -147,6 +147,7 @@ enum
 	TC_DASHMODE,   // For Metal Sonic's dashmode
 	TC_HITLAG,     // Damage hitlag effect
 	TC_INTERMISSION, // Intermission / menu background
+	TC_MULT, // Older version of TC_RAINBOW, looks a bit darker / different per skincolor
 
 	TC_DEFAULT
 };


### PR DESCRIPTION
- Try to fix off-world items with overlapped IDs showing as Ring Racers items 
- Add indicators of the item's progression class
  - Standard Archipelago name coloring
  - Star count, for colorblind friendliness, like ToontownAP