### PR TITLE
Prison Egg CD-sanity

### DIFF
--- a/apworld/data/!manifest.json
+++ b/apworld/data/!manifest.json
@@ -12,6 +12,7 @@
     "challenges_extras.json",
     "challenges_tutorial.json",
     "challenges_lostandfound.json",
+    "challenges_altmusic.json",
     "spray_cans.json",
     "filler.json"
   ]

--- a/apworld/data/challenges_altmusic.json
+++ b/apworld/data/challenges_altmusic.json
@@ -1,0 +1,1247 @@
+{
+	"cups": {},
+	"maps": {},
+	"locations": [
+		{
+			"id": 800,
+			"name": "Challenge - Prison Egg CD #1",
+			"label": "Prison Egg CD #1",
+			"cd_count": 1,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 801,
+			"name": "Challenge - Prison Egg CD #2",
+			"label": "Prison Egg CD #2",
+			"cd_count": 2,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 802,
+			"name": "Challenge - Prison Egg CD #3",
+			"label": "Prison Egg CD #3",
+			"cd_count": 3,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 803,
+			"name": "Challenge - Prison Egg CD #4",
+			"label": "Prison Egg CD #4",
+			"cd_count": 4,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 804,
+			"name": "Challenge - Prison Egg CD #5",
+			"label": "Prison Egg CD #5",
+			"cd_count": 5,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 805,
+			"name": "Challenge - Prison Egg CD #6",
+			"label": "Prison Egg CD #6",
+			"cd_count": 6,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 806,
+			"name": "Challenge - Prison Egg CD #7",
+			"label": "Prison Egg CD #7",
+			"cd_count": 7,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 807,
+			"name": "Challenge - Prison Egg CD #8",
+			"label": "Prison Egg CD #8",
+			"cd_count": 8,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 808,
+			"name": "Challenge - Prison Egg CD #9",
+			"label": "Prison Egg CD #9",
+			"cd_count": 9,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 809,
+			"name": "Challenge - Prison Egg CD #10",
+			"label": "Prison Egg CD #10",
+			"cd_count": 10,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 810,
+			"name": "Challenge - Prison Egg CD #11",
+			"label": "Prison Egg CD #11",
+			"cd_count": 11,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 811,
+			"name": "Challenge - Prison Egg CD #12",
+			"label": "Prison Egg CD #12",
+			"cd_count": 12,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 812,
+			"name": "Challenge - Prison Egg CD #13",
+			"label": "Prison Egg CD #13",
+			"cd_count": 13,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 813,
+			"name": "Challenge - Prison Egg CD #14",
+			"label": "Prison Egg CD #14",
+			"cd_count": 14,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 814,
+			"name": "Challenge - Prison Egg CD #15",
+			"label": "Prison Egg CD #15",
+			"cd_count": 15,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 815,
+			"name": "Challenge - Prison Egg CD #16",
+			"label": "Prison Egg CD #16",
+			"cd_count": 16,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 816,
+			"name": "Challenge - Prison Egg CD #17",
+			"label": "Prison Egg CD #17",
+			"cd_count": 17,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 817,
+			"name": "Challenge - Prison Egg CD #18",
+			"label": "Prison Egg CD #18",
+			"cd_count": 18,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 818,
+			"name": "Challenge - Prison Egg CD #19",
+			"label": "Prison Egg CD #19",
+			"cd_count": 19,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 819,
+			"name": "Challenge - Prison Egg CD #20",
+			"label": "Prison Egg CD #20",
+			"cd_count": 20,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 820,
+			"name": "Challenge - Prison Egg CD #21",
+			"label": "Prison Egg CD #21",
+			"cd_count": 21,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 821,
+			"name": "Challenge - Prison Egg CD #22",
+			"label": "Prison Egg CD #22",
+			"cd_count": 22,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 822,
+			"name": "Challenge - Prison Egg CD #23",
+			"label": "Prison Egg CD #23",
+			"cd_count": 23,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 823,
+			"name": "Challenge - Prison Egg CD #24",
+			"label": "Prison Egg CD #24",
+			"cd_count": 24,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 824,
+			"name": "Challenge - Prison Egg CD #25",
+			"label": "Prison Egg CD #25",
+			"cd_count": 25,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 825,
+			"name": "Challenge - Prison Egg CD #26",
+			"label": "Prison Egg CD #26",
+			"cd_count": 26,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 826,
+			"name": "Challenge - Prison Egg CD #27",
+			"label": "Prison Egg CD #27",
+			"cd_count": 27,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 827,
+			"name": "Challenge - Prison Egg CD #28",
+			"label": "Prison Egg CD #28",
+			"cd_count": 28,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 828,
+			"name": "Challenge - Prison Egg CD #29",
+			"label": "Prison Egg CD #29",
+			"cd_count": 29,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 829,
+			"name": "Challenge - Prison Egg CD #30",
+			"label": "Prison Egg CD #30",
+			"cd_count": 30,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 830,
+			"name": "Challenge - Prison Egg CD #31",
+			"label": "Prison Egg CD #31",
+			"cd_count": 31,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 831,
+			"name": "Challenge - Prison Egg CD #32",
+			"label": "Prison Egg CD #32",
+			"cd_count": 32,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 832,
+			"name": "Challenge - Prison Egg CD #33",
+			"label": "Prison Egg CD #33",
+			"cd_count": 33,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 833,
+			"name": "Challenge - Prison Egg CD #34",
+			"label": "Prison Egg CD #34",
+			"cd_count": 34,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 834,
+			"name": "Challenge - Prison Egg CD #35",
+			"label": "Prison Egg CD #35",
+			"cd_count": 35,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 835,
+			"name": "Challenge - Prison Egg CD #36",
+			"label": "Prison Egg CD #36",
+			"cd_count": 36,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 836,
+			"name": "Challenge - Prison Egg CD #37",
+			"label": "Prison Egg CD #37",
+			"cd_count": 37,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 837,
+			"name": "Challenge - Prison Egg CD #38",
+			"label": "Prison Egg CD #38",
+			"cd_count": 38,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 838,
+			"name": "Challenge - Prison Egg CD #39",
+			"label": "Prison Egg CD #39",
+			"cd_count": 39,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 839,
+			"name": "Challenge - Prison Egg CD #40",
+			"label": "Prison Egg CD #40",
+			"cd_count": 40,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 840,
+			"name": "Challenge - Prison Egg CD #41",
+			"label": "Prison Egg CD #41",
+			"cd_count": 41,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 841,
+			"name": "Challenge - Prison Egg CD #42",
+			"label": "Prison Egg CD #42",
+			"cd_count": 42,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 842,
+			"name": "Challenge - Prison Egg CD #43",
+			"label": "Prison Egg CD #43",
+			"cd_count": 43,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 843,
+			"name": "Challenge - Prison Egg CD #44",
+			"label": "Prison Egg CD #44",
+			"cd_count": 44,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 844,
+			"name": "Challenge - Prison Egg CD #45",
+			"label": "Prison Egg CD #45",
+			"cd_count": 45,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 845,
+			"name": "Challenge - Prison Egg CD #46",
+			"label": "Prison Egg CD #46",
+			"cd_count": 46,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 846,
+			"name": "Challenge - Prison Egg CD #47",
+			"label": "Prison Egg CD #47",
+			"cd_count": 47,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 847,
+			"name": "Challenge - Prison Egg CD #48",
+			"label": "Prison Egg CD #48",
+			"cd_count": 48,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 848,
+			"name": "Challenge - Prison Egg CD #49",
+			"label": "Prison Egg CD #49",
+			"cd_count": 49,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 849,
+			"name": "Challenge - Prison Egg CD #50",
+			"label": "Prison Egg CD #50",
+			"cd_count": 50,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 850,
+			"name": "Challenge - Prison Egg CD #51",
+			"label": "Prison Egg CD #51",
+			"cd_count": 51,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 851,
+			"name": "Challenge - Prison Egg CD #52",
+			"label": "Prison Egg CD #52",
+			"cd_count": 52,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 852,
+			"name": "Challenge - Alt. Music: Popcorn Workshop",
+			"label": "Alt. Music: Popcorn Workshop",
+			"condition_set": 852,
+			"tags": [
+				"Challenges"
+			]
+		},
+		{
+			"id": 853,
+			"name": "Challenge - Prison Egg CD #53",
+			"label": "Prison Egg CD #53",
+			"cd_count": 53,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 900,
+			"name": "Challenge - Prison Egg CD #54",
+			"label": "Prison Egg CD #54",
+			"cd_count": 54,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 901,
+			"name": "Challenge - Prison Egg CD #55",
+			"label": "Prison Egg CD #55",
+			"cd_count": 55,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 902,
+			"name": "Challenge - Prison Egg CD #56",
+			"label": "Prison Egg CD #56",
+			"cd_count": 56,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 903,
+			"name": "Challenge - Prison Egg CD #57",
+			"label": "Prison Egg CD #57",
+			"cd_count": 57,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 904,
+			"name": "Challenge - Prison Egg CD #58",
+			"label": "Prison Egg CD #58",
+			"cd_count": 58,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 905,
+			"name": "Challenge - Prison Egg CD #59",
+			"label": "Prison Egg CD #59",
+			"cd_count": 59,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 906,
+			"name": "Challenge - Prison Egg CD #60",
+			"label": "Prison Egg CD #60",
+			"cd_count": 60,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		},
+		{
+			"id": 907,
+			"name": "Challenge - Prison Egg CD #61",
+			"label": "Prison Egg CD #61",
+			"cd_count": 61,
+			"tags": [
+				"Challenges",
+				"CD Milestones"
+			]
+		}
+	],
+	"items": [
+		{
+			"id": 800,
+			"name": "Alt. Music: Test Run",
+			"label": "Test Run",
+			"unlockable": 800,
+			"song_map": "rr_testrun",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 801,
+			"name": "Alt. Music: Emerald Coast A",
+			"label": "Emerald Coast A",
+			"unlockable": 801,
+			"song_map": "rr_emeraldcoast",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 802,
+			"name": "Alt. Music: Emerald Coast B",
+			"label": "Emerald Coast B",
+			"unlockable": 802,
+			"song_map": "rr_emeraldcoast",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 803,
+			"name": "Alt. Music: Angel Island A",
+			"label": "Angel Island A",
+			"unlockable": 803,
+			"song_map": "rr_angelisland",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 804,
+			"name": "Alt. Music: Angel Island B",
+			"label": "Angel Island B",
+			"unlockable": 804,
+			"song_map": "rr_angelisland",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 805,
+			"name": "Alt. Music: Regal Ruin A",
+			"label": "Regal Ruin A",
+			"unlockable": 805,
+			"song_map": "rr_regalruin",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 806,
+			"name": "Alt. Music: Regal Ruin B",
+			"label": "Regal Ruin B",
+			"unlockable": 806,
+			"song_map": "rr_regalruin",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 807,
+			"name": "Alt. Music: Collision Chaos",
+			"label": "Collision Chaos",
+			"unlockable": 807,
+			"song_map": "rr_collisionchaos",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 808,
+			"name": "Alt. Music: Emerald Hill",
+			"label": "Emerald Hill",
+			"unlockable": 808,
+			"song_map": "rr_emeraldhill",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 809,
+			"name": "Alt. Music: Gust Planet A",
+			"label": "Gust Planet A",
+			"unlockable": 809,
+			"song_map": "rr_gustplanet",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 810,
+			"name": "Alt. Music: Gust Planet B",
+			"label": "Gust Planet B",
+			"unlockable": 810,
+			"song_map": "rr_gustplanet",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 811,
+			"name": "Alt. Music: Mystic Cave A",
+			"label": "Mystic Cave A",
+			"unlockable": 811,
+			"song_map": "rr_mysticcave",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 812,
+			"name": "Alt. Music: Mystic Cave B",
+			"label": "Mystic Cave B",
+			"unlockable": 812,
+			"song_map": "rr_mysticcave",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 813,
+			"name": "Alt. Music: Marble Garden A",
+			"label": "Marble Garden A",
+			"unlockable": 813,
+			"song_map": "rr_marblegarden",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 814,
+			"name": "Alt. Music: Marble Garden B",
+			"label": "Marble Garden B",
+			"unlockable": 814,
+			"song_map": "rr_marblegarden",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 815,
+			"name": "Alt. Music: Launch Base A",
+			"label": "Launch Base A",
+			"unlockable": 815,
+			"song_map": "rr_launchbase",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 816,
+			"name": "Alt. Music: Launch Base B",
+			"label": "Launch Base B",
+			"unlockable": 816,
+			"song_map": "rr_launchbase",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 817,
+			"name": "Alt. Music: City Escape",
+			"label": "City Escape",
+			"unlockable": 817,
+			"song_map": "rr_cityescape",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 818,
+			"name": "Alt. Music: Palmtree Panic A",
+			"label": "Palmtree Panic A",
+			"unlockable": 818,
+			"song_map": "rr_palmtreepanic",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 819,
+			"name": "Alt. Music: Metropolis",
+			"label": "Metropolis",
+			"unlockable": 819,
+			"song_map": "rr_metropolis",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 820,
+			"name": "Alt. Music: Hydro City A",
+			"label": "Hydro City A",
+			"unlockable": 820,
+			"song_map": "rr_hydrocity",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 821,
+			"name": "Alt. Music: Hydro City B",
+			"label": "Hydro City B",
+			"unlockable": 821,
+			"song_map": "rr_hydrocity",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 822,
+			"name": "Alt. Music: Diamond Dust",
+			"label": "Diamond Dust",
+			"unlockable": 822,
+			"song_map": "rr_diamonddust",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 823,
+			"name": "Alt. Music: Carnival Night A",
+			"label": "Carnival Night A",
+			"unlockable": 823,
+			"song_map": "rr_carnivalnight",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 824,
+			"name": "Alt. Music: Carnival Night B",
+			"label": "Carnival Night B",
+			"unlockable": 824,
+			"song_map": "rr_carnivalnight",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 825,
+			"name": "Alt. Music: Dark Fortress",
+			"label": "Dark Fortress",
+			"unlockable": 825,
+			"song_map": "rr_darkfortress",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 826,
+			"name": "Alt. Music: Hot Shelter",
+			"label": "Hot Shelter",
+			"unlockable": 826,
+			"song_map": "rr_hotshelter",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 827,
+			"name": "Alt. Music: Mega Lava Reef",
+			"label": "Mega Lava Reef",
+			"unlockable": 827,
+			"song_map": "rr_megalavareef",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 828,
+			"name": "Alt. Music: Quartz Quadrant",
+			"label": "Quartz Quadrant",
+			"unlockable": 828,
+			"song_map": "rr_quartzquadrant",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 829,
+			"name": "Alt. Music: Aqua Tunnel",
+			"label": "Aqua Tunnel",
+			"unlockable": 829,
+			"song_map": "rr_aquatunnel",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 830,
+			"name": "Alt. Music: Abyss Garden",
+			"label": "Abyss Garden",
+			"unlockable": 830,
+			"song_map": "rr_abyssgarden",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 831,
+			"name": "Alt. Music: Monkey Mall",
+			"label": "Monkey Mall",
+			"unlockable": 831,
+			"song_map": "rr_monkeymall",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 832,
+			"name": "Alt. Music: Crimson Core",
+			"label": "Crimson Core",
+			"unlockable": 832,
+			"song_map": "rr_crimsoncore",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 833,
+			"name": "Alt. Music: Mega Collision Chaos",
+			"label": "Mega Collision Chaoss",
+			"unlockable": 833,
+			"song_map": "rr_megacollisionchaos",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 834,
+			"name": "Alt. Music: Diamond Dust Classic",
+			"label": "Diamond Dust Classic",
+			"unlockable": 834,
+			"song_map": "rr_diamonddustclassic",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 835,
+			"name": "Alt. Music: Nova Shore",
+			"label": "Nova Shore",
+			"unlockable": 835,
+			"song_map": "rr_novashore",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 836,
+			"name": "Alt. Music: Weiss Waterway",
+			"label": "Weiss Waterway",
+			"unlockable": 836,
+			"song_map": "rr_weisswaterway",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 837,
+			"name": "Alt. Music: Mirage Saloon A",
+			"label": "Mirage Saloon A",
+			"unlockable": 837,
+			"song_map": "rr_miragesaloon",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 838,
+			"name": "Alt. Music: Mirage Saloon B",
+			"label": "Mirage Saloon B",
+			"unlockable": 838,
+			"song_map": "rr_miragesaloon",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 839,
+			"name": "Alt. Music: Hill Top",
+			"label": "Hill Top",
+			"unlockable": 839,
+			"song_map": "rr_hilltop",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 840,
+			"name": "Alt. Music: Palmtree Panic B",
+			"label": "Palmtree Panic B",
+			"unlockable": 840,
+			"song_map": "rr_palmtreepanic",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 841,
+			"name": "Alt. Music: Test Track",
+			"label": "Test Track",
+			"unlockable": 841,
+			"song_map": "rr_testtrack",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 842,
+			"name": "Alt. Music: Thunder Piston A",
+			"label": "Thunder Piston A",
+			"unlockable": 842,
+			"song_map": "rr_thunderpiston",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 843,
+			"name": "Alt. Music: Azure City",
+			"label": "Azure City",
+			"unlockable": 843,
+			"song_map": "rr_azurecity",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 844,
+			"name": "Alt. Music: Fae Falls",
+			"label": "Fae Falls",
+			"unlockable": 844,
+			"song_map": "rr_faefalls",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 845,
+			"name": "Alt. Music: Speed Highway",
+			"label": "Speed Highway",
+			"unlockable": 845,
+			"song_map": "rr_speedhighway",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 846,
+			"name": "Alt. Music: Daytona Speedway",
+			"label": "Daytona Speedway",
+			"unlockable": 846,
+			"song_map": "rr_daytonaspeedway",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 847,
+			"name": "Alt. Music: Storm Rig",
+			"label": "Storm Rig",
+			"unlockable": 847,
+			"song_map": "rr_stormrig",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 848,
+			"name": "Alt. Music: Cadillac Cascade",
+			"label": "Cadillac Cascade",
+			"unlockable": 848,
+			"song_map": "rr_cadillaccascade",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 849,
+			"name": "Alt. Music: Frozen Production",
+			"label": "Frozen Production",
+			"unlockable": 849,
+			"song_map": "rr_frozenproduction",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 850,
+			"name": "Alt. Music: Cyan Belltower",
+			"label": "Cyan Belltower",
+			"unlockable": 850,
+			"song_map": "rr_cyanbelltower",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 851,
+			"name": "Alt. Music: Chaos Chute",
+			"label": "Chaos Chute",
+			"unlockable": 851,
+			"song_map": "rr_chaostube",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 852,
+			"name": "Alt. Music: Popcorn Workshop",
+			"label": "Popcorn Workshop",
+			"unlockable": 852,
+			"song_map": "rr_popcornworkshop",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 853,
+			"name": "Alt. Music: Thunder Piston B",
+			"label": "Thunder Piston B",
+			"unlockable": 853,
+			"song_map": "rr_thunderpiston",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 900,
+			"name": "Alt. Music: CD Special Stage 1",
+			"label": "CD Special Stage 1",
+			"unlockable": 900,
+			"song_map": "rr_cdspecialstage1",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 901,
+			"name": "Alt. Music: CD Special Stage 8",
+			"label": "CD Special Stage 8",
+			"unlockable": 901,
+			"song_map": "rr_cdspecialstage8",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 902,
+			"name": "Alt. Music: Wood",
+			"label": "Wood",
+			"unlockable": 902,
+			"song_map": "rr_wood",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 903,
+			"name": "Alt. Music: Rusty Rig",
+			"label": "Rusty Rig",
+			"unlockable": 903,
+			"song_map": "rr_rustyrig",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 904,
+			"name": "Alt. Music: Dead Simple",
+			"label": "Dead Simple",
+			"unlockable": 904,
+			"song_map": "rr_deadsimple",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 905,
+			"name": "Alt. Music: Marble Foyer",
+			"label": "Marble Foyer",
+			"unlockable": 905,
+			"song_map": "rr_marblefoyer",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 906,
+			"name": "Alt. Music: Cyber Arena",
+			"label": "Cyber Arena",
+			"unlockable": 906,
+			"song_map": "rr_cyberarena",
+			"tags": [
+				"Alt. Music"
+			]
+		},
+		{
+			"id": 907,
+			"name": "Alt. Music: Duel Busters",
+			"label": "Duel Busters",
+			"unlockable": 907,
+			"song_map": "rr_duelbuster",
+			"tags": [
+				"Alt. Music"
+			]
+		}
+	]
+}

--- a/apworld/items.py
+++ b/apworld/items.py
@@ -22,7 +22,7 @@ class RingRacersItem(Item):
 
 
 def get_random_filler_item_name(world: RingRacersWorld) -> str:
-    return "Temporary Filler"
+    return "KKD Honor"
 
 
 def create_rr_item(world: RingRacersWorld, name: str) -> RingRacersItem:
@@ -35,6 +35,9 @@ def create_rr_item(world: RingRacersWorld, name: str) -> RingRacersItem:
         classification = ItemClassification.progression_deprioritized_skip_balancing
     elif name in world.item_name_groups["Spray Cans"]:
         # Progression by technicality, because of Gum's Challenge
+        classification = ItemClassification.progression_deprioritized_skip_balancing
+    elif name in world.item_name_groups["Alt. Music"]:
+        # Progression by technicality, because of Sound Test's Challenge
         classification = ItemClassification.progression_deprioritized_skip_balancing
     elif name in world.item_name_groups["Drivers"]:
         # There's probably 1 or 2 drivers that aren't required for challenges,
@@ -81,10 +84,10 @@ def create_all_items(world: RingRacersWorld) -> None:
     for color_name in world.item_name_groups["Spray Cans"]:
         color_pool.append(world.create_item(color_name)) 
 
-    num_spray_cans_left = len(world.location_name_groups["Spray Cans"]) - len(color_pool)
-    for _ in range(num_spray_cans_left):
-        color_pool.append(world.create_item("KKD Honor"))
-    logging.debug('RingRacers:: Created {} filler honors'.format(num_spray_cans_left))
+    #num_spray_cans_left = len(world.location_name_groups["Spray Cans"]) - len(color_pool)
+    #for _ in range(num_spray_cans_left):
+    #    color_pool.append(world.create_item("KKD Honor"))
+    #logging.debug('RingRacers:: Created {} filler honors'.format(num_spray_cans_left))
 
     item_pool: list[Item] = []
     item_pool += driver_pool
@@ -99,6 +102,9 @@ def create_all_items(world: RingRacersWorld) -> None:
 
     for extra_name in world.item_name_groups["Extras"]:
         item_pool.append(world.create_item(extra_name))
+
+    for music_name in world.item_name_groups["Alt. Music"]:
+        item_pool.append(world.create_item(music_name))
 
     number_of_items = len(item_pool)
     number_of_unfilled_locations = len(world.multiworld.get_unfilled_locations(world.player))

--- a/apworld/locations.py
+++ b/apworld/locations.py
@@ -51,6 +51,18 @@ def create_events(world: RingRacersWorld) -> None:
             location_type=RingRacersLocation, item_type=items.RingRacersItem
         )
 
+        for map_index in cup_def["map_list"]:
+            map_def = jsondata.rr_map_defs[map_index]
+            if map_def["type"] == "battle":
+                map_name = map_def["label"]
+                map_region = world.get_region(map_name)
+
+                event_name = "!" + map_name + " Bonus Round"
+                map_region.add_event(
+                    event_name, "!Bonus Round Reachable",
+                    location_type=RingRacersLocation, item_type=items.RingRacersItem
+                )
+
     for index, map_def in jsondata.rr_map_defs.items():
         map_name = map_def["label"]
         map_region = world.get_region(map_name)

--- a/apworld/rules.py
+++ b/apworld/rules.py
@@ -319,7 +319,8 @@ def set_driver_challenge_location_rules(world: RingRacersWorld) -> None:
         lambda state:
             have_group_percentage(state, "Spray Cans", world.player, 75)
     )
-    gum_location.progress_type = LocationProgressType.EXCLUDED # TEMPORARY!
+    # Requires over 50% of colors, exclude
+    gum_location.progress_type = LocationProgressType.EXCLUDED
 
     set_rule(
         world.get_location("Challenge - Driver: Gutbuster"),
@@ -1723,9 +1724,8 @@ def set_extras_challenge_location_rules(world: RingRacersWorld) -> None:
     set_rule(
         sound_test_location,
         lambda state:
-            True #have_group_percentage(state, "Alt Music", world.player, 25)
+            have_group_percentage(state, "Alt. Music", world.player, 25)
     )
-    sound_test_location.progress_type = LocationProgressType.EXCLUDED # TEMPORARY!
 
     #
     # "Challenge - Playing with Addons" is always possible, currently
@@ -1789,16 +1789,47 @@ def set_extras_challenge_location_rules(world: RingRacersWorld) -> None:
     # "Challenge - Lost & Found: Duel Busters" is always possible, currently
     #
 
-    #
-    # This location works right now, but let's wait until we get the
-    # rest of the Alt Music locations implemented.
-    #
 
-    #set_rule(
-    #    world.get_location("Challenge - Alt Music: Popcorn Workshop"),
-    #    lambda state:
-    #        map_time_attack(state, "Popcorn Workshop", world.player)
-    #)
+def set_alt_music_challenge_location_rules(world: RingRacersWorld) -> None:
+    milestone_locations = list(world.location_name_groups["CD Milestones"])
+
+    total_bonus_rounds = 0
+    for index, cup_def in jsondata.rr_cup_defs.items():
+        for map_index in cup_def["map_list"]:
+            map_def = jsondata.rr_map_defs[map_index]
+            if map_def["type"] == "battle":
+                total_bonus_rounds += 1
+
+    # exclude more than 50%
+    included_bonus_rounds = total_bonus_rounds // 2
+
+    cd_counter = 1
+    for _ in milestone_locations:
+        location_name = "Challenge - Prison Egg CD #{}".format(cd_counter)
+        location = world.get_location(location_name)
+
+        required_bonus_rounds = min(cd_counter, total_bonus_rounds)
+        set_rule(
+            location,
+            lambda state, rounds=required_bonus_rounds:
+                state.has("!Bonus Round Reachable", world.player, rounds)
+        )
+
+        if required_bonus_rounds > included_bonus_rounds:
+            # exclude this location, since it explicitly requires grinding
+            location.progress_type = LocationProgressType.EXCLUDED
+
+        cd_counter += 1
+
+    # Don't forget this one weirdo
+    popcorn_workshop_location = world.get_location("Challenge - Alt. Music: Popcorn Workshop")
+    set_rule(
+        popcorn_workshop_location,
+        lambda state:
+            map_time_attack(state, "Popcorn Workshop", world.player)
+    )
+    # Requires platinum medal
+    popcorn_workshop_location.progress_type = LocationProgressType.EXCLUDED
 
 
 def set_challenge_location_rules(world: RingRacersWorld) -> None:
@@ -1806,6 +1837,7 @@ def set_challenge_location_rules(world: RingRacersWorld) -> None:
     set_follower_challenge_location_rules(world)
     set_cup_challenge_location_rules(world)
     set_extras_challenge_location_rules(world)
+    set_alt_music_challenge_location_rules(world)
 
 
 def set_all_location_rules(world: RingRacersWorld) -> None:

--- a/apworld/utils/soc_to_json.py
+++ b/apworld/utils/soc_to_json.py
@@ -298,7 +298,7 @@ for id_str, unlockable in soc.get("unlockable", {}).items():
 		item["name"] = temp_name
 		item["label"] = temp_name
 		item["unlockable"] = id_int
-		item["color"] = unlockable["var"].lower()
+		item["song_map"] = unlockable["var"].lower()
 		item["tags"] = ["Alt. Music"]
 
 		locations.append(location)

--- a/src/ap_main.cpp
+++ b/src/ap_main.cpp
@@ -76,6 +76,7 @@ rrap_location_t::rrap_location_t(srb2::JsonValue json)
 	_big_tile = json.value("big_tile", false);
 
 	_condition_set_id = json.value("condition_set", 0);
+	_prison_cd_count = json.value("cd_count", 0);
 	_spray_can_map_id = 0;
 
 	srb2::String spray_can_map_name = json.value("spray_can_map", srb2::String(""));
@@ -510,6 +511,16 @@ char *RRAP_LocationLabel(rrap_location_t *location)
 	}
 
 	return Z_StrDup( location->label().c_str() );
+}
+
+UINT8 RRAP_LocationPrisonCDCount(rrap_location_t *location)
+{
+	if (!location)
+	{
+		return 0;
+	}
+
+	return location->prison_cd_count();
 }
 
 INT32 RRAP_LocationSprayCanMapID(rrap_location_t *location)

--- a/src/ap_main.h
+++ b/src/ap_main.h
@@ -44,6 +44,7 @@ private:
 	boolean _check_pending;
 
 	UINT16 _condition_set_id;
+	UINT8 _prison_cd_count;
 	INT32 _spray_can_map_id;
 	boolean _big_tile;
 
@@ -63,6 +64,7 @@ public:
 	boolean check_pending() const { return _check_pending; }
 
 	UINT16 condition_set_id() const { return _condition_set_id; }
+	UINT8 prison_cd_count() const { return _prison_cd_count; }
 	INT32 spray_can_map_id() const { return _spray_can_map_id; }
 	boolean is_big_tile() const { return _big_tile; }
 
@@ -99,6 +101,12 @@ public:
 
 	boolean achieved() const
 	{
+		UINT8 prison_cds = prison_cd_count();
+		if (prison_cds > 0)
+		{
+			return (gamedata->numprisoneggpickups >= prison_cds);
+		}
+
 		INT32 spray_can_map = spray_can_map_id();
 		if (spray_can_map > 0)
 		{
@@ -191,6 +199,7 @@ boolean RRAP_LocationAvailable(rrap_location_t *location);
 boolean RRAP_LocationAchieved(rrap_location_t *location);
 char *RRAP_LocationLabel(rrap_location_t *location);
 UINT16 RRAP_LocationConditionSet(rrap_location_t *location);
+UINT8 RRAP_LocationPrisonCDCount(rrap_location_t *location);
 INT32 RRAP_LocationSprayCanMapID(rrap_location_t *location);
 boolean RRAP_LocationIsBigTile(rrap_location_t *location);
 boolean RRAP_LocationChecked(rrap_location_t *location);

--- a/src/doomstat.h
+++ b/src/doomstat.h
@@ -908,6 +908,9 @@ extern tic_t attacktimingstarted;
 extern boolean inDuel;
 extern UINT8 overtimecheckpoints;
 
+// [RRAP]
+extern UINT8 g_prisoneggstothispickup;
+
 extern tic_t bombflashtimer;	// Used to avoid causing seizures if multiple mines explode close to you :)
 extern boolean legitimateexit;
 extern boolean comebackshowninfo;

--- a/src/g_game.c
+++ b/src/g_game.c
@@ -318,6 +318,9 @@ tic_t attacktimingstarted; // For Time Attack
 boolean inDuel; // Boolean, keeps track of if it is a 1v1
 UINT8 overtimecheckpoints; // Duel overtime speedups!
 
+// [RRAP]
+UINT8 g_prisoneggstothispickup = UINT8_MAX;
+
 // Client-sided, unsynched variables (NEVER use in anything that needs to be synced with other players)
 tic_t bombflashtimer = 0;	// Cooldown before another FlashPal can be intialized by a bomb exploding near a displayplayer. Avoids seizures.
 boolean legitimateexit; // Did this client actually finish the match?

--- a/src/g_gamedata.cpp
+++ b/src/g_gamedata.cpp
@@ -89,8 +89,6 @@ void srb2::save_ng_gamedata()
 	ng.milestones.tutorialdone = gamedata->tutorialdone;
 	ng.milestones.playgroundroute = gamedata->playgroundroute;
 	ng.milestones.gonerlevel = gamedata->gonerlevel;
-	ng.prisons.thisprisoneggpickup = gamedata->thisprisoneggpickup;
-	ng.prisons.prisoneggstothispickup = gamedata->prisoneggstothispickup;
 	ng.tafolderhash = quickncasehash(timeattackfolder, 64);
 	ng.emblems.resize(MAXEMBLEMS, false);
 	for (int i = 0; i < MAXEMBLEMS; i++)
@@ -470,13 +468,6 @@ void srb2::load_ng_gamedata()
 	gamedata->tutorialdone = js.milestones.tutorialdone;
 	gamedata->playgroundroute = js.milestones.playgroundroute;
 	gamedata->gonerlevel = js.milestones.gonerlevel;
-	gamedata->thisprisoneggpickup = js.prisons.thisprisoneggpickup;
-
-	gamedata->prisoneggstothispickup = js.prisons.prisoneggstothispickup;
-	if (gamedata->prisoneggstothispickup > GDINIT_PRISONSTOPRIZE)
-	{
-		gamedata->prisoneggstothispickup = GDINIT_PRISONSTOPRIZE;
-	}
 
 	size_t emblems_size = js.emblems.size();
 	for (size_t i = 0; i < std::min((size_t)MAXEMBLEMS, emblems_size); i++)

--- a/src/g_gamedata.h
+++ b/src/g_gamedata.h
@@ -115,14 +115,6 @@ struct GamedataMilestonesJson final
 	)
 };
 
-struct GamedataPrisonEggPickupsJson final
-{
-	uint16_t thisprisoneggpickup;
-	uint16_t prisoneggstothispickup;
-
-	SRB2_JSON_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(GamedataPrisonEggPickupsJson, thisprisoneggpickup, prisoneggstothispickup)
-};
-
 struct GamedataChallengeGridJson final
 {
 	// [RRAP]
@@ -292,7 +284,9 @@ struct GamedataJson final
 	GamedataRoundsJson rounds;
 	GamedataChallengeKeysJson challengekeys;
 	GamedataMilestonesJson milestones;
+#if 0
 	GamedataPrisonEggPickupsJson prisons;
+#endif
 	uint32_t tafolderhash;
 	Vector<bool> emblems;
 #if 0
@@ -316,7 +310,9 @@ struct GamedataJson final
 		rounds,
 		challengekeys,
 		milestones,
+#if 0
 		prisons,
+#endif
 		tafolderhash,
 		emblems,
 #if 0

--- a/src/k_kart.c
+++ b/src/k_kart.c
@@ -412,8 +412,6 @@ void K_TimerInit(void)
 		battleprisons == true
 		&& grandprixinfo.gp == true
 		&& netgame == false
-		&& gamedata->thisprisoneggpickup_cached != NULL
-		&& gamedata->prisoneggstothispickup == 0
 		&& maptargets > 1
 	)
 	{
@@ -421,7 +419,7 @@ void K_TimerInit(void)
 		// - You can't get a Prison Egg Drop on the last broken target
 		// - If it were 0 at minimum there'd be a slight bias towards the start of the round
 		//    - This is bad because it benefits CD farming like in Brawl :D
-		gamedata->prisoneggstothispickup = 1 + M_RandomKey(maptargets - 1);
+		g_prisoneggstothispickup = 1 + M_RandomKey(maptargets - 1);
 	}
 }
 

--- a/src/m_cond.c
+++ b/src/m_cond.c
@@ -395,12 +395,7 @@ void M_ClearSecrets(void)
 	memset(netUnlocked, 0, sizeof(netUnlocked));
 	memset(gamedata->achieved, 0, sizeof(gamedata->achieved));
 
-	Z_Free(gamedata->prisoneggpickups);
-	gamedata->prisoneggpickups = NULL;
 	gamedata->numprisoneggpickups = 0;
-	gamedata->thisprisoneggpickup = MAXCONDITIONSETS;
-	gamedata->thisprisoneggpickup_cached = NULL;
-	gamedata->thisprisoneggpickupgrabbed = false;
 
 	UINT16 i, j;
 	for (i = 0; i < nummapheaders; i++)
@@ -443,7 +438,6 @@ void M_ClearSecrets(void)
 	gamedata->keyspending = 0;
 
 	gamedata->chaokeys = GDINIT_CHAOKEYS;
-	gamedata->prisoneggstothispickup = GDINIT_PRISONSTOPRIZE;
 
 	gamedata->tutorialdone = false;
 	gamedata->playgroundroute = false;
@@ -612,7 +606,6 @@ static void M_AssignSpraycans(void)
 		gamedata->numspraycans++;
 	}
 }
-#endif
 
 static void M_InitPrisonEggPickups(void)
 {
@@ -822,6 +815,7 @@ cacheprisoneggpickup:
 
 #endif // DEVELOP
 }
+#endif
 
 static void M_PrecacheLevelLocks(void)
 {
@@ -967,10 +961,10 @@ void M_FinaliseGameData(void)
 #if 0 // [RRAP]
 	// Place the spraycans, which CAN'T be done lazily.
 	M_AssignSpraycans();
-#endif
 
 	// You could probably do the Prison Egg Pickups lazily, but it'd be a lagspike mid-combat.
 	M_InitPrisonEggPickups();
+#endif
 
 	// Don't consider loaded until it's a success!
 	// It used to do this much earlier, but this would cause the gamedata
@@ -1475,7 +1469,11 @@ boolean M_CheckCondition(condition_t *cn, player_t *player)
 		}
 
 		case UC_PRISONEGGCD:
+#if 0
 			return ((gamedata->thisprisoneggpickupgrabbed == true) && (cn == gamedata->thisprisoneggpickup_cached));
+#else
+			return false; // [RRAP]
+#endif
 
 		// Just for string building
 		case UC_AND:
@@ -2837,6 +2835,27 @@ char *M_BuildConditionSetString(INT64 ap_location_id)
 		len--;
 	}
 
+	UINT8 cd_count = RRAP_LocationPrisonCDCount(location);
+	if (cd_count)
+	{
+		work = va(
+			"GRAND PRIX: grab %d CD%s from Prison Eggs",
+			cd_count,
+			(cd_count == 1) ? "" : "s"
+		);
+		worklen = strlen(work);
+		strncat(message, work, len);
+		len -= worklen;
+
+		return V_ScaledWordWrap(
+			DESCRIPTIONWIDTH << FRACBITS,
+			FRACUNIT, FRACUNIT, FRACUNIT,
+			0,
+			TINY_FONT,
+			message
+		);
+	}
+
 	INT32 spray_can_map = RRAP_LocationSprayCanMapID(location);
 	if (spray_can_map)
 	{
@@ -3070,7 +3089,9 @@ boolean M_UpdateUnlockablesAndExtraEmblems(boolean loud, boolean doall)
 	{
 		response = M_CheckUnlockConditions(NULL);
 
+#if 0 // [RRAP]
 		M_UpdateNextPrisonEggPickup();
+#endif
 
 		if (gamedata->pendingkeyrounds == 0
 			|| (gamedata->chaokeys >= GDMAX_CHAOKEYS))

--- a/src/m_cond.h
+++ b/src/m_cond.h
@@ -356,11 +356,6 @@ struct gamedata_t
 
 	// PRISON EGG PICKUPS
 	UINT16 numprisoneggpickups;
-	UINT16 thisprisoneggpickup;
-	condition_t *thisprisoneggpickup_cached;
-	boolean thisprisoneggpickupgrabbed;
-	UINT16 prisoneggstothispickup;
-	UINT16* prisoneggpickups;
 
 	// CHALLENGE GRID
 	INT64 ap_challengegridwidth;
@@ -463,7 +458,9 @@ UINT16 M_CheckCupEmeralds(UINT8 difficulty);
 boolean M_CheckCondition(condition_t *cn, player_t *player);
 boolean M_UpdateUnlockablesAndExtraEmblems(boolean loud, boolean doall);
 
+#if 0 // [RRAP]
 void M_UpdateNextPrisonEggPickup(void);
+#endif
 
 UINT16 M_CheckLevelEmblems(void);
 UINT16 M_CompletionEmblems(void);

--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -911,18 +911,13 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher, boolean heightcheck)
 				if (
 					grandprixinfo.gp == true // Bonus Round
 					&& netgame == false // game design + makes it easier to implement
-					&& gamedata->thisprisoneggpickup_cached != NULL
 				)
 				{
-					gamedata->thisprisoneggpickupgrabbed = true;
-					if (gamedata->prisoneggstothispickup < GDINIT_PRISONSTOPRIZE)
-					{
-						// Just in case it's set absurdly low for testing.
-						gamedata->prisoneggstothispickup = GDINIT_PRISONSTOPRIZE;
-					}
+					gamedata->numprisoneggpickups++;
 
 					if (!M_UpdateUnlockablesAndExtraEmblems(true, true))
 						S_StartSound(NULL, sfx_ncitem);
+
 					gamedata->deferredsave = true;
 				}
 
@@ -1234,9 +1229,9 @@ static void P_AddBrokenPrison(mobj_t *target, mobj_t *inflictor, mobj_t *source)
 
 	P_TrackRoundConditionTargetDamage(targetdamaging);
 
-	if (gamedata->prisoneggstothispickup)
+	if (g_prisoneggstothispickup)
 	{
-		gamedata->prisoneggstothispickup--;
+		g_prisoneggstothispickup--;
 	}
 
 	// Standard progression.
@@ -1309,17 +1304,15 @@ static void P_AddBrokenPrison(mobj_t *target, mobj_t *inflictor, mobj_t *source)
 			grandprixinfo.gp == true // Bonus Round
 			&& demo.playback == false // Not playback
 			&& netgame == false // game design + makes it easier to implement
-			&& gamedata->thisprisoneggpickup_cached != NULL
-			&& gamedata->prisoneggstothispickup == 0
-			&& gamedata->thisprisoneggpickupgrabbed == false
+			&& g_prisoneggstothispickup == 0
 			)
 #ifdef DEVELOP
-			|| (cv_debugprisoncd.value && gamedata->thisprisoneggpickup_cached != NULL)
+			|| (cv_debugprisoncd.value)
 #endif
 		)
 		{
 			// Will be 0 for the next level
-			gamedata->prisoneggstothispickup = (maptargets - numtargets);
+			g_prisoneggstothispickup = (maptargets - numtargets);
 
 			mobj_t *secretpickup = P_SpawnMobj(
 				target->x, target->y,

--- a/src/p_mobj.c
+++ b/src/p_mobj.c
@@ -7801,11 +7801,8 @@ static boolean P_MobjRegularThink(mobj_t *mobj)
 		}
 		else if (!netgame)
 		{
-			if (gamedata->thisprisoneggpickup_cached->type == UC_PRISONEGGCD)
-			{
-				teststate = S_PRISONEGGDROP_CD;
-				mobj->renderflags |= RF_SEMIBRIGHT;
-			}
+			teststate = S_PRISONEGGDROP_CD;
+			mobj->renderflags |= RF_SEMIBRIGHT;
 
 			P_SetMobjStateNF(mobj, teststate);
 


### PR DESCRIPTION
Resolves #4
Resolves #15

- Adds Alt. Music as items
  - Sound Test's Challenge is now possible
- Adds Prison Egg CD milestones for each Alt. Music
  - There is exactly one more Alt. Music than there are Prison Break maps, so these needed to be kept as milestones instead of changed per-map like Spray Cans were. I think this is OK, it serves a decent contrast from the Spray Can challenges, and Grand Prix is longer to revisit than just opening up Match Race.
  - Only the first 50% are included, the rest are given filler.
  - Logic is expecting that you only get 2 per unlocked cup. No revisits are necessary unless if you miss a CD.
- KKD Honors are officially now the filler item of the game, instead of "temporary filler".